### PR TITLE
Add initial apiModel to file conversion functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ last-data-access-refresh.conf
 /dataFromApi/*.csv
 /dataFromApi/*.json
 
+/temp

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ simpleConfigSaverTest.conf
 /src/main/resources/configuration.conf
 simple-config-saver-key.conf
 last-data-access-refresh.conf
+
+# Data files (might contain sensitive data)
+/dataFromApi/*.csv
+/dataFromApi/*.json
+

--- a/dataFromApi/README.md
+++ b/dataFromApi/README.md
@@ -1,0 +1,2 @@
+Electricity Data Consolidator uses this directory to place the
+data files (e.g. `.csv` files) made from external API data.

--- a/src/main/java/me/noitcereon/ApiModelToDataFileConverter.java
+++ b/src/main/java/me/noitcereon/ApiModelToDataFileConverter.java
@@ -30,7 +30,7 @@ public class ApiModelToDataFileConverter {
         }
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath.toFile()))) {
             for (T model : dataModels) {
-                writer.write(model.toString());
+                writer.write(model.toString()); // TODO Implement Model to CSV conversion and this test. toString() is not really a valid option.
             }
             writer.flush();
         }

--- a/src/main/java/me/noitcereon/ApiModelToDataFileConverter.java
+++ b/src/main/java/me/noitcereon/ApiModelToDataFileConverter.java
@@ -1,0 +1,53 @@
+package me.noitcereon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.noitcereon.external.api.eloverblik.models.MeteringPointApiDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * A class that handles conversion from Java object to data file, such as a .csv file.<br/>
+ * For example:
+ * It can take a {@link MeteringPointApiDto} and write its contents into a .csv file.
+ *
+ * @apiNote This is an initial version that might be abstracted further upon later.
+ * If needed, a "DataFileToApiModelConverter" class might be made as well.
+ */
+public class ApiModelToDataFileConverter {
+    private static final Path OUTPUT_DIRECTORY_PATH = Paths.get(System.getProperty("user.dir") + File.separator + "dataFromApi");
+    private static final Logger LOG = LoggerFactory.getLogger(ApiModelToDataFileConverter.class);
+
+    public <T> void createCsvFile(List<T> dataModels, String fileName) throws IOException {
+        Path filePath = Paths.get(OUTPUT_DIRECTORY_PATH.toString(), fileName);
+        if (dataModels == null || dataModels.isEmpty()) {
+            LOG.warn("Cannot create .csv file from nothing: dataModels=" + dataModels);
+            return;
+        }
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath.toFile()))) {
+            for (T model : dataModels) {
+                writer.write(model.toString());
+            }
+            writer.flush();
+        }
+    }
+    public <T> MethodOutcome createJsonFile(List<T> dataModels, String fileName) throws IOException {
+        Path filePath = Paths.get(OUTPUT_DIRECTORY_PATH.toString(), fileName);
+        if (dataModels == null || dataModels.isEmpty()) {
+            LOG.warn("Cannot create .json file from nothing: dataModels=" + dataModels);
+            return MethodOutcome.BAD_INPUT_FAILURE;
+        }
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath.toFile()))) {
+            ObjectMapper mapper = new ObjectMapper();
+            for (T model : dataModels) {
+                mapper.writeValue(filePath.toFile(), model);
+            }
+            writer.flush();
+        }
+        return MethodOutcome.SUCCESS;
+    }
+}

--- a/src/main/java/me/noitcereon/MethodOutcome.java
+++ b/src/main/java/me/noitcereon/MethodOutcome.java
@@ -1,0 +1,8 @@
+package me.noitcereon;
+
+/**
+ * Indicator of whether a method call succeeded or failed.
+ */
+public enum MethodOutcome {
+    SUCCESS, FAILURE, BAD_INPUT_FAILURE
+}

--- a/src/test/java/me/noitcereon/ApiModelToDataFileConverterTest.java
+++ b/src/test/java/me/noitcereon/ApiModelToDataFileConverterTest.java
@@ -1,0 +1,55 @@
+package me.noitcereon;
+
+import me.noitcereon.exceptions.ElectricityConsolidatorRuntimeException;
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ApiModelToDataFileConverterTest {
+
+    private static ApiModelToDataFileConverter unitUnderTest;
+
+    @BeforeAll
+    public static void initializeTest() {
+        unitUnderTest = new ApiModelToDataFileConverter();
+    }
+
+    @Test
+    public void givenModelData_WhenConvertingToCsvFile_ThenFileIsCreated() throws IOException {
+        TempModel model = new TempModel();
+        model.name = "Jessica";
+        model.age = 22;
+        List<TempModel> tempList = new ArrayList<>();
+        tempList.add(model);
+
+        // Act and Assert (no exceptions)
+        unitUnderTest.createCsvFile(tempList, "tempModel.csv");
+    }
+    @Test
+    public void givenModelData_WhenConvertingToJsonFile_ThenFileIsCreated() throws IOException {
+        MethodOutcome expectedOutcome = MethodOutcome.SUCCESS;
+        TempModel model = new TempModel();
+        model.name = "Noitcereon";
+        model.age = 26;
+        List<TempModel> tempList = new ArrayList<>();
+        tempList.add(model);
+        // Act
+        MethodOutcome actualOutcome = unitUnderTest.createJsonFile(tempList, "tempModel.json");
+        // Assert
+        Assertions.assertEquals(expectedOutcome, actualOutcome);
+    }
+
+    /**
+     * Temporary model to test with... Should be replaced with a more realistic scenario.
+     */
+    class TempModel {
+        public String name;
+        public int age;
+        @Override
+        public String toString(){
+            return this.name + ";" + this.age;
+        }
+    }
+}

--- a/src/test/java/me/noitcereon/ApiModelToDataFileConverterTest.java
+++ b/src/test/java/me/noitcereon/ApiModelToDataFileConverterTest.java
@@ -28,6 +28,20 @@ public class ApiModelToDataFileConverterTest {
         unitUnderTest.createCsvFile(tempList, "tempModel.csv");
     }
     @Test
+    public void givenModeldata_WhenConvertingToCsvFile_ThenDataWrittenMatchesDataGiven() throws IOException {
+        // TODO: Implement Model to CSV conversion and this test. (test part)
+        /*
+            Use test data (based on real api model) to convert into CSV file.
+            Then, make assertions that the CSV file contains the same data.
+         */
+
+        // Act
+        // unitUnderTest.createCsvFile(testData, "givenModeldata_WhenConvertingToCsvFile_ThenDataWrittenMatchesDataGiven.csv");
+
+        // Assert
+        Assertions.fail("Conversion from datamodel to CSV file has not been implemented yet.");
+    }
+    @Test
     public void givenModelData_WhenConvertingToJsonFile_ThenFileIsCreated() throws IOException {
         MethodOutcome expectedOutcome = MethodOutcome.SUCCESS;
         TempModel model = new TempModel();

--- a/src/test/java/me/noitcereon/CustomJunitTag.java
+++ b/src/test/java/me/noitcereon/CustomJunitTag.java
@@ -1,0 +1,5 @@
+package me.noitcereon;
+
+public class CustomJunitTag {
+    public static final String INTEGRATION_TEST = "IntegrationTest";
+}

--- a/src/test/java/me/noitcereon/external/api/eloverblik/ElOverblikApiControllerTest.java
+++ b/src/test/java/me/noitcereon/external/api/eloverblik/ElOverblikApiControllerTest.java
@@ -1,5 +1,6 @@
 package me.noitcereon.external.api.eloverblik;
 
+import me.noitcereon.CustomJunitTag;
 import me.noitcereon.configuration.SimpleConfigLoader;
 import me.noitcereon.configuration.SimpleConfigSaver;
 import org.junit.jupiter.api.BeforeAll;
@@ -10,7 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@Tag("IntegrationTest")
+@Tag(CustomJunitTag.INTEGRATION_TEST)
 class ElOverblikApiControllerTest {
 
     private static ElOverblikApiController controller;


### PR DESCRIPTION
> Note: Build does not pass because of an intentional fail in unit test (unmade functionality)

## Changes
- Add apiModel to .json file conversion
- Add skeleton for apiModel to .csv file conversion (.csv file todo added)
- .gitignore updated
- Reworked IntegrationTest tag with the introduction of src/test/java/me/noitcereon/CustomJunitTag.java