### PR TITLE
Fix: Fetch data from all meteringpoints instead of only some

### DIFF
--- a/src/main/java/me/noitcereon/console/ui/ScreenOptionFactory.java
+++ b/src/main/java/me/noitcereon/console/ui/ScreenOptionFactory.java
@@ -46,7 +46,7 @@ public class ScreenOptionFactory {
         LocalDate yesterday = LocalDate.now().minusDays(1);
         LocalDate dayBeforeYesterDay = yesterday.minusDays(1);
         return new ScreenOption("Fetch meterdata from yesterday (" + yesterday + ")", () -> {
-            Optional<List<MeteringPointApiDto>> meteringPoints = elOverblikApi.getMeteringPoints(false);
+            Optional<List<MeteringPointApiDto>> meteringPoints = elOverblikApi.getMeteringPoints(true);
             if(meteringPoints.isEmpty()){
                 LOG.error("Failed to retrieve meteringsPoints from API, so can't fetch MeterData.");
                 throw new ElectricityConsolidatorRuntimeException("No metering points, so can't continue.");
@@ -73,7 +73,7 @@ public class ScreenOptionFactory {
         LocalDate fromDate = latestFetchDate;
         LocalDate toDate = LocalDate.now().minusDays(1);
         return new ScreenOption("Fetch MeterData based on latest fetch date (from %s to %s)".formatted(fromDate, toDate), () -> {
-            Optional<List<MeteringPointApiDto>> meteringPoints = elOverblikApi.getMeteringPoints(false);
+            Optional<List<MeteringPointApiDto>> meteringPoints = elOverblikApi.getMeteringPoints(true);
             if(meteringPoints.isEmpty()){
                 LOG.error("Failed to retrieve meteringsPoints from API, so can't fetch MeterData.");
                 throw new ElectricityConsolidatorRuntimeException("No metering points, so can't continue.");
@@ -93,7 +93,7 @@ public class ScreenOptionFactory {
                 LocalDate dateFrom = LocalDate.parse(Screen.getScannerInstance().nextLine());
                 System.out.println("Enter dateTo in format YYYY-MM-DD");
                 LocalDate dateTo = LocalDate.parse(Screen.getScannerInstance().nextLine());
-                Optional<List<MeteringPointApiDto>> meteringPoints = elOverblikApi.getMeteringPoints(false);
+                Optional<List<MeteringPointApiDto>> meteringPoints = elOverblikApi.getMeteringPoints(true);
                 if(meteringPoints.isEmpty()){
                     LOG.error("Failed to retrieve meteringsPoints from API, so can't fetch MeterData.");
                     throw new ElectricityConsolidatorRuntimeException("No metering points, so can't continue.");

--- a/src/main/java/me/noitcereon/external/api/eloverblik/models/MeteringPointsRequest.java
+++ b/src/main/java/me/noitcereon/external/api/eloverblik/models/MeteringPointsRequest.java
@@ -6,9 +6,18 @@ import java.util.List;
 @EloverblikApiModel
 public record MeteringPointsRequest (MeteringPoints meteringPoints){
     public static MeteringPointsRequest from(List<MeteringPointApiDto> meteringPointApiDtos) {
+       return from(meteringPointApiDtos, true);
+    }
+    public static MeteringPointsRequest from(List<MeteringPointApiDto> meteringPointApiDtos, boolean includeChildMeteringPoints) {
         List<String> meteringPoints = new ArrayList<>();
-        for (MeteringPointApiDto item : meteringPointApiDtos){
-            meteringPoints.add(item.getMeteringPointId());
+        for (MeteringPointApiDto meteringPoint : meteringPointApiDtos){
+            meteringPoints.add(meteringPoint.getMeteringPointId());
+            if(meteringPoint.getChildMeteringPoints().isEmpty() || !includeChildMeteringPoints){
+                continue; // Don't try to add child metering points.
+            }
+            for (ChildMeteringPointDto childMeteringPoint : meteringPoint.getChildMeteringPoints()) {
+                meteringPoints.add(childMeteringPoint.getMeteringPointId());
+            }
         }
         return new MeteringPointsRequest(new MeteringPoints(meteringPoints));
     }


### PR DESCRIPTION
To ensure that the data you want is there.
Ideally this should be configurable without a recompile, but that is not included in this PR.